### PR TITLE
Add a note explaining that in order to use the tools you must install…

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -152,10 +152,9 @@ you can use the following command to re-serialize the whole repo::
 
     $ python tools/reserialize.py --all .
 
-**Note:** Before using the tools, you should install some packages. In order to
-obtain them, you can run the following command::
-
-    $ pip install -r tools/requirements.txt
+.. note:: Before using the tools, you should install some packages. In order to
+   obtain them, you can run the following command::
+       $ pip install -r tools/requirements.txt
 
 Finally, video JSON files should go in a directory called ``videos`` that is
 itself inside a category directory. For example::

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -152,6 +152,11 @@ you can use the following command to re-serialize the whole repo::
 
     $ python tools/reserialize.py --all .
 
+**Note:** Before using the tools, you should install some packages. In order to
+obtain them, you can run the following command::
+
+    $ pip install -r tools/requirements.txt
+
 Finally, video JSON files should go in a directory called ``videos`` that is
 itself inside a category directory. For example::
 


### PR DESCRIPTION
… the packages listed in the new requirements.txt file.

This note is only in the CONTRIBUTING file, in the section on pretty printing
the json files.

If there are other places where the tooling is mentioned, this note should be
adde there too, or a redistribution fo the documentation should be done.